### PR TITLE
Expose postal code in checkout details

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,5 @@
+PAYPAL_USERNAME=changeme
+PAYPAL_PASSWORD=changeme
+PAYPAL_SIGNATURE=changeme
+PAYPAL_SELLER_ID=changeme
+PAYPAL_EMAIL=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ doc/app
 *~
 .DS_Store
 .rvmrc
+.env

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,31 +6,50 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.2.3)
-      i18n (~> 0.6)
-      multi_json (~> 1.0)
-    awesome_print (1.0.2)
-    coderay (1.0.6)
-    diff-lcs (1.1.3)
+    activesupport (5.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    awesome_print (1.7.0)
+    byebug (9.0.6)
+    coderay (1.1.1)
+    concurrent-ruby (1.0.4)
+    diff-lcs (1.2.5)
     fakeweb (1.3.0)
-    i18n (0.6.0)
-    method_source (0.7.1)
-    multi_json (1.3.2)
-    pry (0.9.9.3)
-      coderay (~> 1.0.5)
-      method_source (~> 0.7.1)
-      slop (>= 2.4.4, < 3)
-    rake (0.9.2.2)
-    rspec (2.10.0)
-      rspec-core (~> 2.10.0)
-      rspec-expectations (~> 2.10.0)
-      rspec-mocks (~> 2.10.0)
-    rspec-core (2.10.1)
-    rspec-expectations (2.10.0)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.10.1)
-    slop (2.4.4)
-    vcr (2.1.0)
+    i18n (0.7.0)
+    its (0.2.0)
+      rspec-core
+    method_source (0.8.2)
+    minitest (5.10.1)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.2)
+      byebug (~> 9.0)
+      pry (~> 0.10)
+    rake (12.0.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-collection_matchers (1.1.3)
+      rspec-expectations (>= 2.99.0.beta1)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    slop (3.6.0)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    vcr (3.0.3)
 
 PLATFORMS
   ruby
@@ -39,8 +58,13 @@ DEPENDENCIES
   activesupport
   awesome_print
   fakeweb
+  its
   paypal-recurring!
-  pry
+  pry-byebug
   rake
   rspec
+  rspec-collection_matchers
   vcr
+
+BUNDLED WITH
+   1.12.5

--- a/lib/paypal/recurring/base.rb
+++ b/lib/paypal/recurring/base.rb
@@ -72,7 +72,7 @@ module PayPal
           :item_quantity
         ).merge(
           :payment_action => "Authorization",
-          :no_shipping => 1,
+          :no_shipping => 0,
           :L_BILLINGTYPE0 => "RecurringPayments"
         )
 

--- a/lib/paypal/recurring/response/details.rb
+++ b/lib/paypal/recurring/response/details.rb
@@ -5,7 +5,6 @@ module PayPal
         mapping(
           :status       => :CHECKOUTSTATUS,
           :email        => :EMAIL,
-          :email        => :EMAIL,
           :payer_id     => :PAYERID,
           :payer_status => :PAYERSTATUS,
           :first_name   => :FIRSTNAME,

--- a/lib/paypal/recurring/response/details.rb
+++ b/lib/paypal/recurring/response/details.rb
@@ -14,7 +14,8 @@ module PayPal
           :currency     => :CURRENCYCODE,
           :amount       => :AMT,
           :description  => :DESC,
-          :ipn_url      => :NOTIFYURL
+          :ipn_url      => :NOTIFYURL,
+          :postal_code  => :POSTALCODE
         )
 
         def agreed?

--- a/lib/paypal/recurring/response/details.rb
+++ b/lib/paypal/recurring/response/details.rb
@@ -14,7 +14,7 @@ module PayPal
           :amount       => :AMT,
           :description  => :DESC,
           :ipn_url      => :NOTIFYURL,
-          :postal_code  => :POSTALCODE
+          :postal_code  => :SHIPTOZIP
         )
 
         def agreed?

--- a/paypal-recurring.gemspec
+++ b/paypal-recurring.gemspec
@@ -18,10 +18,12 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "rspec"
+  s.add_development_dependency "its"
+  s.add_development_dependency "rspec-collection_matchers"
   s.add_development_dependency "rake"
   s.add_development_dependency "vcr"
   s.add_development_dependency "fakeweb"
-  s.add_development_dependency "pry"
+  s.add_development_dependency "pry-byebug"
   s.add_development_dependency "awesome_print"
   s.add_development_dependency "activesupport"
 end

--- a/spec/fixtures/details/success.yml
+++ b/spec/fixtures/details/success.yml
@@ -5,34 +5,49 @@ http_interactions:
     uri: https://api-3t.sandbox.paypal.com/nvp
     body:
       encoding: US-ASCII
-      string: USER=fnando.vieira%2Bseller_api1.gmail.com&PWD=PRTZZX6JDACB95SA&SIGNATURE=AJnjtLN0ozBP-BF2ZJrj5sfbmGAxAnf5tev1-MgK5Z8IASmtj-Fw.5pt&VERSION=72.0&TOKEN=EC-08C2125544495393T&METHOD=GetExpressCheckoutDetails
+      string: USER=<PAYPAL_USERNAME>&PWD=<PAYPAL_PASSWORD>&SIGNATURE=<PAYPAL_SIGNATURE>&VERSION=72.0&TOKEN=EC-90D28589JF9704647&METHOD=GetExpressCheckoutDetails
     headers:
+      accept-encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       accept:
-      - ! '*/*'
+      - "*/*"
       user-agent:
-      - PayPal::Recurring/0.1.8
+      - PayPal::Recurring/1.1.0
       content-type:
       - application/x-www-form-urlencoded
-      connection:
-      - close
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Mon, 23 Apr 2012 03:46:33 GMT
+      - Tue, 24 Jan 2017 16:05:08 GMT
       server:
       - Apache
-      content-length:
-      - '1048'
+      x-slr-retry-api:
+      - GetExpressCheckoutDetails
+      x-paypal-operation-name:
+      - GetExpressCheckoutDetails
+      x-paypal-api-rc:
+      - ''
       connection:
       - close
+      http_x_pp_az_locator:
+      - sandbox.slc
+      paypal-debug-id:
+      - 1435fda0821c2
+      set-cookie:
+      - X-PP-SILOVER=name%3DSANDBOX3.API.1%26silo_version%3D1880%26app%3Dappdispatcher_apit%26TIME%3D880510808%26HTTP_X_PP_AZ_LOCATOR%3Dsandbox.slc;
+        Expires=Tue, 24 Jan 2017 16:35:09 GMT; domain=.paypal.com; path=/; Secure;
+        HttpOnly
+      - X-PP-SILOVER=; Expires=Thu, 01 Jan 1970 00:00:01 GMT
+      content-length:
+      - '1344'
       content-type:
       - text/plain; charset=utf-8
     body:
-      encoding: US-ASCII
-      string: TOKEN=EC%2d08C2125544495393T&BILLINGAGREEMENTACCEPTEDSTATUS=1&CHECKOUTSTATUS=PaymentActionNotInitiated&TIMESTAMP=2012%2d04%2d23T03%3a46%3a33Z&CORRELATIONID=2d6423eb9e64d&ACK=Success&VERSION=72%2e0&BUILD=2808426&EMAIL=fnando%2evieira%2bbr%40gmail%2ecom&PAYERID=D2U7M6PTMJBML&PAYERSTATUS=unverified&FIRSTNAME=Jos%c3%a9&LASTNAME=da%20Silva&COUNTRYCODE=BR&TAXIDTYPE=BR_CPF&TAXID=42519601140&CURRENCYCODE=BRL&AMT=9%2e00&SHIPPINGAMT=0%2e00&HANDLINGAMT=0%2e00&TAXAMT=0%2e00&DESC=Awesome%20%2d%20Monthly%20Subscription&NOTIFYURL=http%3a%2f%2fexample%2ecom%2fpaypal%2fipn&INSURANCEAMT=0%2e00&SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_CURRENCYCODE=BRL&PAYMENTREQUEST_0_AMT=9%2e00&PAYMENTREQUEST_0_SHIPPINGAMT=0%2e00&PAYMENTREQUEST_0_HANDLINGAMT=0%2e00&PAYMENTREQUEST_0_TAXAMT=0%2e00&PAYMENTREQUEST_0_DESC=Awesome%20%2d%20Monthly%20Subscription&PAYMENTREQUEST_0_NOTIFYURL=http%3a%2f%2fexample%2ecom%2fpaypal%2fipn&PAYMENTREQUEST_0_INSURANCEAMT=0%2e00&PAYMENTREQUEST_0_SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_INSURANCEOPTIONOFFERED=false&PAYMENTREQUESTINFO_0_ERRORCODE=0
+      encoding: UTF-8
+      string: TOKEN=EC%2d90D28589JF9704647&BILLINGAGREEMENTACCEPTEDSTATUS=1&CHECKOUTSTATUS=PaymentActionNotInitiated&TIMESTAMP=2017%2d01%2d24T16%3a05%3a09Z&CORRELATIONID=1435fda0821c2&ACK=Success&VERSION=72%2e0&BUILD=28806785&EMAIL=maji%2dtest%2dbuyer%40charitywater%2eorg&PAYERID=KV8YLGHNPVT8Q&PAYERSTATUS=verified&FIRSTNAME=Maji&LASTNAME=Test&COUNTRYCODE=US&SHIPTONAME=Maji%20Test&SHIPTOSTREET=1%20Main%20St&SHIPTOCITY=San%20Jose&SHIPTOSTATE=CA&SHIPTOZIP=95131&SHIPTOCOUNTRYCODE=US&SHIPTOCOUNTRYNAME=United%20States&ADDRESSSTATUS=Confirmed&CURRENCYCODE=USD&AMT=41%2e70&SHIPPINGAMT=0%2e00&HANDLINGAMT=0%2e00&TAXAMT=0%2e00&DESC=Monthly%20Giving&INSURANCEAMT=0%2e00&SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_CURRENCYCODE=USD&PAYMENTREQUEST_0_AMT=41%2e70&PAYMENTREQUEST_0_SHIPPINGAMT=0%2e00&PAYMENTREQUEST_0_HANDLINGAMT=0%2e00&PAYMENTREQUEST_0_TAXAMT=0%2e00&PAYMENTREQUEST_0_DESC=Monthly%20Giving&PAYMENTREQUEST_0_INSURANCEAMT=0%2e00&PAYMENTREQUEST_0_SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_INSURANCEOPTIONOFFERED=false&PAYMENTREQUEST_0_SHIPTONAME=Maji%20Test&PAYMENTREQUEST_0_SHIPTOSTREET=1%20Main%20St&PAYMENTREQUEST_0_SHIPTOCITY=San%20Jose&PAYMENTREQUEST_0_SHIPTOSTATE=CA&PAYMENTREQUEST_0_SHIPTOZIP=95131&PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE=US&PAYMENTREQUEST_0_SHIPTOCOUNTRYNAME=United%20States&PAYMENTREQUEST_0_ADDRESSSTATUS=Confirmed&PAYMENTREQUESTINFO_0_ERRORCODE=0
     http_version: '1.1'
-  recorded_at: Mon, 23 Apr 2012 03:46:34 GMT
-recorded_with: VCR 2.1.0
+  recorded_at: Tue, 24 Jan 2017 16:05:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/paypal/recurring_spec.rb
+++ b/spec/paypal/recurring_spec.rb
@@ -25,7 +25,7 @@ describe PayPal::Recurring do
         config.sandbox = false
       end
 
-      PayPal::Recurring.sandbox.should be_false
+      PayPal::Recurring.sandbox.should be false
     end
   end
 

--- a/spec/paypal/request_spec.rb
+++ b/spec/paypal/request_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe PayPal::Recurring::Request do
   describe "#client" do
     it "uses SSL" do
-      subject.client.use_ssl?.should be_true
+      subject.client.use_ssl?.should be true
     end
 
     it "verifies certificate" do

--- a/spec/paypal/response/base_spec.rb
+++ b/spec/paypal/response/base_spec.rb
@@ -6,13 +6,13 @@ describe PayPal::Recurring::Response do
   describe ".mapping" do
     it "returns single item mapping" do
       response_class.mapping :foo => :bar
-      response = response_class.new(stub(:body => "bar=foo"))
+      response = response_class.new(double(:resp, body: "bar=foo"))
       response.foo.should == "foo"
     end
 
     it "returns item from array mapping" do
       response_class.mapping :foo => [:bar, :zaz]
-      response = response_class.new(stub(:body => "zaz=foo"))
+      response = response_class.new(double(:resp, body: "zaz=foo"))
       response.foo.should == "foo"
     end
   end

--- a/spec/paypal/response/checkout_details_spec.rb
+++ b/spec/paypal/response/checkout_details_spec.rb
@@ -1,11 +1,11 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe PayPal::Recurring::Response::Details do
   context "when successful" do
-    use_vcr_cassette "details/success"
+    use_vcr_cassette("details/success")
 
     subject {
-      ppr = PayPal::Recurring.new(:token => "EC-08C2125544495393T")
+      ppr = PayPal::Recurring.new(:token => "EC-90D28589JF9704647")
       ppr.checkout_details
     }
 
@@ -14,15 +14,16 @@ describe PayPal::Recurring::Response::Details do
 
     its(:errors) { should be_empty }
     its(:status) { should == "PaymentActionNotInitiated" }
-    its(:email) { should == "fnando.vieira+br@gmail.com" }
+    its(:email) { should == "maji-test-buyer@charitywater.org" }
     its(:requested_at) { should be_a(Time) }
-    its(:payer_id) { should == "D2U7M6PTMJBML" }
-    its(:payer_status) { should == "unverified" }
-    its(:country) { should == "BR" }
-    its(:currency) { should == "BRL" }
-    its(:description) { should == "Awesome - Monthly Subscription" }
-    its(:ipn_url) { should == "http://example.com/paypal/ipn" }
-    its(:agreed?) { should be_true }
+    its(:payer_id) { should == "KV8YLGHNPVT8Q" }
+    its(:payer_status) { should == "verified" }
+    its(:country) { should == "US" }
+    its(:currency) { should == "USD" }
+    its(:description) { should == "Monthly Giving" }
+    its(:ipn_url) { should be nil }
+    its(:agreed?) { should be true }
+    its(:postal_code) { should == "95131" }
   end
 
   context "when cancelled" do
@@ -35,7 +36,7 @@ describe PayPal::Recurring::Response::Details do
     it { should be_valid }
     it { should be_success }
 
-    its(:agreed?) { should be_false }
+    its(:agreed?) { should be false }
   end
 
   context "when failure" do

--- a/spec/paypal/response/checkout_spec.rb
+++ b/spec/paypal/response/checkout_spec.rb
@@ -17,7 +17,7 @@ describe PayPal::Recurring::Response::Checkout do
       ppr.checkout
     }
 
-    its(:valid?) { should be_true }
+    its(:valid?) { should be true }
     its(:errors) { should be_empty }
     its(:checkout_url) { should == "#{PayPal::Recurring.site_endpoint}?cmd=_express-checkout&token=EC-6K296451S2213041J&useraction=commit" }
   end
@@ -26,7 +26,7 @@ describe PayPal::Recurring::Response::Checkout do
     use_vcr_cassette("checkout/failure")
     subject { PayPal::Recurring.new.checkout }
 
-    its(:valid?) { should be_false }
+    its(:valid?) { should be false }
     its(:errors) { should have(3).items }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,23 +5,33 @@ Bundler.require
 require "paypal-recurring"
 require "vcr"
 require "active_support/all"
+require 'pry-byebug'
+require 'its'
+require 'rspec/collection_matchers'
 
 VCR.configure do |config|
   config.cassette_library_dir = File.dirname(__FILE__) + "/fixtures"
   config.hook_into :fakeweb
+  config.filter_sensitive_data("<PAYPAL_USERNAME>") { ENV["PAYPAL_USERNAME"] }
+  config.filter_sensitive_data("<PAYPAL_PASSWORD>") { ENV["PAYPAL_PASSWORD"] }
+  config.filter_sensitive_data("<PAYPAL_SIGNATURE>") { ENV["PAYPAL_SIGNATURE"] }
+  config.filter_sensitive_data("<PAYPAL_SELLER_ID>") { ENV["PAYPAL_SELLER_ID"] }
+  config.filter_sensitive_data("<PAYPAL_EMAIL>") { ENV["PAYPAL_EMAIL"] }
 end
 
 RSpec.configure do |config|
   config.extend VCR::RSpec::Macros
 
   config.before do
+    FakeWeb.clean_registry
+
     PayPal::Recurring.configure do |config|
-      config.sandbox = true
-      config.username = "fnando.vieira+seller_api1.gmail.com"
-      config.password = "PRTZZX6JDACB95SA"
-      config.signature = "AJnjtLN0ozBP-BF2ZJrj5sfbmGAxAnf5tev1-MgK5Z8IASmtj-Fw.5pt"
-      config.seller_id = "F2RM85WS56YX2"
-      config.email = "fnando.vieira+seller.gmail.com"
+       config.sandbox = true
+       config.username = ENV["PAYPAL_USERNAME"]
+       config.password = ENV["PAYPAL_PASSWORD"]
+       config.signature = ENV["PAYPAL_SIGNATURE"]
+       config.seller_id = ENV["PAYPAL_SELLER_ID"]
+       config.email = ENV["PAYPAL_EMAIL"]
     end
   end
 end


### PR DESCRIPTION
This branch turns off the `:no_shipping` flag on checkout so that when checkout details are retrieved for a recurring profile, they include the postal code.

[#137450807](https://www.pivotaltracker.com/story/show/137450807)

Note: 
- I removed the gem author's paypal credentials since they weren't working anyway (and all the necessary cassettes are present)
- I also abandoned the effort to replace Fakeweb with Webmock because it was too much work and there was a simple fix to make the whole suite pass (`Fakeweb.clean_registry`)