### PR TITLE
Expose checkout details shipping country

### DIFF
--- a/lib/paypal/recurring/response/details.rb
+++ b/lib/paypal/recurring/response/details.rb
@@ -14,7 +14,8 @@ module PayPal
           :amount       => :AMT,
           :description  => :DESC,
           :ipn_url      => :NOTIFYURL,
-          :postal_code  => :SHIPTOZIP
+          :postal_code  => :SHIPTOZIP,
+          :shipping_country => :SHIPTOCOUNTRYCODE
         )
 
         def agreed?

--- a/lib/paypal/recurring/version.rb
+++ b/lib/paypal/recurring/version.rb
@@ -2,7 +2,7 @@ module PayPal
   module Recurring
     module Version
       MAJOR = 1
-      MINOR = 2
+      MINOR = 3
       PATCH = 0
       STRING = "#{MAJOR}.#{MINOR}.#{PATCH}"
     end

--- a/spec/paypal/response/checkout_details_spec.rb
+++ b/spec/paypal/response/checkout_details_spec.rb
@@ -24,6 +24,7 @@ describe PayPal::Recurring::Response::Details do
     its(:ipn_url) { should be nil }
     its(:agreed?) { should be true }
     its(:postal_code) { should == "95131" }
+    its(:shipping_country) { should == "US" }
   end
 
   context "when cancelled" do


### PR DESCRIPTION
So that we can check the country code against the shipping country code, since a mismatch raises a `ProfileCreateError` for recurring subscribers.

[#175831027](https://www.pivotaltracker.com/story/show/175831027)